### PR TITLE
Taplytics 2.10.44 Release

### DIFF
--- a/Segment-Taplytics.podspec
+++ b/Segment-Taplytics.podspec
@@ -22,5 +22,5 @@ s.requires_arc = true
 s.source_files = 'Segment-Taplytics/Classes/**/*'
 
 s.dependency 'Analytics', '~> 3.0'
-s.dependency 'Taplytics', '~> 2.10.40'
+s.dependency 'Taplytics', '~> 2.10'
 end


### PR DESCRIPTION
- updating dependency to `'~> 2.10'` as mentioned in previous PR.
