### PR TITLE
Update Taplytics to 2.12.*

### DIFF
--- a/Segment-Taplytics.podspec
+++ b/Segment-Taplytics.podspec
@@ -22,5 +22,5 @@ s.requires_arc = true
 s.source_files = 'Segment-Taplytics/Classes/**/*'
 
 s.dependency 'Analytics', '~> 3.0'
-s.dependency 'Taplytics', '~> 2.10'
+s.dependency 'Taplytics', '~> 2.12'
 end

--- a/Segment-Taplytics/Classes/SEGTaplyticsIntegration.m
+++ b/Segment-Taplytics/Classes/SEGTaplyticsIntegration.m
@@ -22,7 +22,7 @@
         [options setValue:[self delayLoad] forKey:@"delayLoad"];
         [options setValue:[self shakeMenu] forKey:@"shakeMenu"];
         [options setValue:[self pushSandbox] forKey:@"pushSandbox"];
-        [options setValue:[self taplyticsOptionSessionBackgroundTime] forKey:@"TaplyticsOptionSessionBackgroundTime"];
+        [options setValue:[self taplyticsOptionSessionBackgroundTime] forKey:@"sessionBackgroundTime"];
         
         [self.taplyticsClass startTaplyticsAPIKey:apiKey options:settings];
         SEGLog(@"[[Taplytics startTaplyticsAPIKey:%@ options:%@]]", apiKey, settings);


### PR DESCRIPTION
- Updated Taplytics to 2.12.*
- Also fixed const TaplyticsOptionSessionBackgroundTime to set correct key value in options map
