### PR TITLE
Call track async

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,1 +1,1 @@
-/Users/prateek/dev/src/github.com/square/spacecommander/.clang-format
+/Users/ladannasserian/Development/spacecommander/.clang-format

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ Carthage
 # `pod install` in .travis.yml
 #
 Pods/
+.clang-format

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,10 +1,10 @@
 PODS:
-  - Analytics (3.6.0)
+  - Analytics (3.6.1)
   - Expecta (1.0.5)
   - OCHamcrest (6.1.1)
   - OCMockito (4.1.0):
     - OCHamcrest (~> 6.0)
-  - Segment-Taplytics (1.1.0):
+  - Segment-Taplytics (1.1.1):
     - Analytics (~> 3.0)
     - Taplytics (~> 2.15.5)
   - Specta (1.0.6)
@@ -21,14 +21,14 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Analytics: 15be3e651d22cc811f44df65698538236676437b
+  Analytics: 32f2d1e0e5499c493450192726b0b42d43606b82
   Expecta: e1c022fcd33910b6be89c291d2775b3fe27a89fe
   OCHamcrest: 363e1bf738c3e8a94abe7c2c415f70d671adde38
   OCMockito: bceefcd365252bcdf8b59c1b2bd23890805fc0d8
-  Segment-Taplytics: 9ac62b08938eb7545e1dec4413a2715e533b4997
+  Segment-Taplytics: d28bfc562b08450eb4fa1eb7a868cbc716e3da05
   Specta: f506f3a8361de16bc0dcf3b17b75e269072ba465
   Taplytics: ff5a5fb99967b1b3a3348b7d3a3d3fa39c1cff2d
 
 PODFILE CHECKSUM: 628429fdb506eb32767cc4ec540d911f0f52ca03
 
-COCOAPODS: 1.2.0
+COCOAPODS: 1.2.1

--- a/Example/Segment-Taplytics.xcodeproj/project.pbxproj
+++ b/Example/Segment-Taplytics.xcodeproj/project.pbxproj
@@ -350,7 +350,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		EEF0D1A269A243F35F74BE70 /* [CP] Check Pods Manifest.lock */ = {
@@ -365,7 +365,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		F9600015AA49289B9E97C4BE /* [CP] Embed Pods Frameworks */ = {

--- a/Segment-Taplytics/Classes/SEGTaplyticsIntegration.h
+++ b/Segment-Taplytics/Classes/SEGTaplyticsIntegration.h
@@ -21,6 +21,5 @@
 - (instancetype)initWithSettings:(NSDictionary *)settings andTaplytics:(id)taplyticsClass;
 
 - (instancetype)initWithSettingsAndSkipTaplyticsIntialization:(NSDictionary *)settings;
-- (void)callTrack;
 
 @end

--- a/Segment-Taplytics/Classes/SEGTaplyticsIntegration.h
+++ b/Segment-Taplytics/Classes/SEGTaplyticsIntegration.h
@@ -21,5 +21,6 @@
 - (instancetype)initWithSettings:(NSDictionary *)settings andTaplytics:(id)taplyticsClass;
 
 - (instancetype)initWithSettingsAndSkipTaplyticsIntialization:(NSDictionary *)settings;
+- (void)callTrack;
 
 @end

--- a/Segment-Taplytics/Classes/SEGTaplyticsIntegration.m
+++ b/Segment-Taplytics/Classes/SEGTaplyticsIntegration.m
@@ -187,11 +187,21 @@
         });
     }
 }
-
-- (void)reset
+- (void)callReset
 {
     SEGLog(@"Taplytics resetUser");
     [self.taplyticsClass resetUser:nil];
+}
+
+- (void)reset
+{
+    if ([NSThread isMainThread]) {
+        [self callReset];
+    } else {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self callReset];
+        });
+    }
 }
 
 - (NSString *)apiKey

--- a/Segment-Taplytics/Classes/SEGTaplyticsIntegration.m
+++ b/Segment-Taplytics/Classes/SEGTaplyticsIntegration.m
@@ -142,6 +142,17 @@
 
 - (void)track:(SEGTrackPayload *)payload
 {
+    if ([NSThread isMainThread]) {
+        [self callTrack:payload];
+    } else {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self callTrack:payload];
+        });
+    }
+}
+
+- (void)callTrack:(SEGTrackPayload *)payload
+{
     NSMutableDictionary *mutablePayload = [NSMutableDictionary dictionaryWithDictionary:payload.properties];
 
     NSNumber *revenue = [SEGTaplyticsIntegration extractRevenue:payload.properties withKey:@"revenue"];

--- a/Segment-Taplytics/Classes/SEGTaplyticsIntegrationFactory.m
+++ b/Segment-Taplytics/Classes/SEGTaplyticsIntegrationFactory.m
@@ -9,11 +9,13 @@
 #import "SEGTaplyticsIntegrationFactory.h"
 #import "SEGTaplyticsIntegration.h"
 
-@interface SEGTaplyticsIntegrationFactory()
+
+@interface SEGTaplyticsIntegrationFactory ()
 
 @property (nonatomic, assign) BOOL skipInit;
 
 @end
+
 
 @implementation SEGTaplyticsIntegrationFactory
 
@@ -50,7 +52,7 @@
     if (self.skipInit) {
         return [[SEGTaplyticsIntegration alloc] initWithSettingsAndSkipTaplyticsIntialization:settings];
     }
-    
+
     return [[SEGTaplyticsIntegration alloc] initWithSettings:settings];
 }
 


### PR DESCRIPTION
Fixes #17 

All public API calls to the Taplytics SDK are dispatched synchronously:

```
#define dispatch_main_sync_safe(block)\
if ([NSThread isMainThread]) {\
    block();\
} else {\
    dispatch_sync(dispatch_get_main_queue(), block);\
}
```

This is causing deadlock issues with our analytics-ios SDK on key lifecycle events which must be handled synchronously. To resolve this, we will call the Taplytics SDK asynchronously.  
