### PR TITLE
Tracking Segment screens as Taplytics events.

### DIFF
--- a/Segment-Taplytics/Classes/SEGTaplyticsIntegration.m
+++ b/Segment-Taplytics/Classes/SEGTaplyticsIntegration.m
@@ -187,6 +187,25 @@
         });
     }
 }
+
+- (void)callScreen:(SEGScreenPayload *)payload
+{
+    NSString *eventName = [NSString stringWithFormat:@"Viewed %@ screen", payload.name];
+    [self.taplyticsClass logEvent:eventName value:nil metaData: payload.properties];
+    SEGLog(@"[[Taplytics sharedInstance] logEvent:%@ value:nil metaData:%@]", eventName, payload.properties);
+}
+
+- (void)screen:(SEGScreenPayload *)payload
+{
+    if ([NSThread isMainThread]) {
+        [self callScreen:payload];
+    } else {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self callScreen:payload];
+        });
+    }
+}
+
 - (void)callReset
 {
     SEGLog(@"Taplytics resetUser");


### PR DESCRIPTION
The problem: 
Taplytics dosn't have concept of screens. Before TodayTix started using Taplytics we already track a lot of screens to Segement. To measure Taplytics goals we do need to have these screens as event in Taplytics.

Proposal:
Let's track all Segment screens as event in Taplytics. 
Here the format for new event names:
`Viewed {screen_name} screen`

This PR is start tracking all screens without any option to dissable this feature. So I am wonder if it will be possible to add some settings variable on Segment UI, so then we could use it in source code to turn this feature on or off. 
