### PR TITLE
chore: updated taplytics dependency to 4

### DIFF
--- a/Segment-Taplytics.podspec
+++ b/Segment-Taplytics.podspec
@@ -23,5 +23,5 @@ s.static_framework = true
 s.source_files = 'Segment-Taplytics/Classes/**/*'
 
 s.dependency 'Analytics'
-s.dependency 'Taplytics', '~> 3'
+s.dependency 'Taplytics', '~> 4'
 end


### PR DESCRIPTION
# Summary

Updated dependency to `4` which supports xcframeworks in cocoapods